### PR TITLE
Fix Jekyll build error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gemspec
 
 gem "webrick", "~> 1.7"
 gem 'jemoji'
+gem "ffi", "< 1.17.0"


### PR DESCRIPTION
To work around ffi-1.17.0-x86_64-linux-musl requires rubygems version >= 3.3.22

 https://github.com/ffi/ffi/issues/1103
